### PR TITLE
fix(ci): pin repo-boundaries checkout action

### DIFF
--- a/.github/workflows/repo-boundaries.yml
+++ b/.github/workflows/repo-boundaries.yml
@@ -16,19 +16,17 @@ on:
       - "**/*.yml"
       - "**/*.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   verify-repo-boundaries:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: Verify no reverse imports or forbidden downstream references
         run: |
-          python scripts/verify_repo_boundaries.py
+          python3 scripts/verify_repo_boundaries.py


### PR DESCRIPTION
## Summary

- pins `actions/checkout` in `repo-boundaries.yml` to a full commit SHA
- removes `actions/setup-python`, because `scripts/verify_repo_boundaries.py` uses only the Python standard library
- adds read-only workflow permissions

## Scope

CI-only patch. No ontology, formal anchor, Vortex, README, or runtime logic changed.

## Reason

The current repo boundary check fails because GitHub Actions are required to be pinned to full-length commit SHAs instead of floating tags like `@v4` / `@v5`.