### PR TITLE
Add ANCHOR_D_ADMISSIBLE_CURVATURE_DOMAIN.md

### DIFF
--- a/anchors/ANCHOR_D_ADMISSIBLE_CURVATURE_DOMAIN.md
+++ b/anchors/ANCHOR_D_ADMISSIBLE_CURVATURE_DOMAIN.md
@@ -1,0 +1,889 @@
+# VECTAETOS — ANCHOR: 𝒟 / Δ / E / κ / QE
+## Admissible Curvature Domain of Φ
+
+Status: CANONICAL ANCHOR  
+Layer: Ontological / Meta-Mathematical  
+Scope: Admissible Curvature Domain of Φ  
+Lineage: VECTAETOS 1.x  
+Authority: Descriptive Only  
+Agency: None  
+Optimization: None  
+Feedback: None  
+
+---
+
+## 0. Purpose
+
+This anchor defines the admissible curvature domain **𝒟** of the VECTAETOS epistemic field.
+
+𝒟 is not an algorithm.  
+𝒟 is not a scoring space.  
+𝒟 is not a safety filter.  
+𝒟 is not a decision boundary.  
+𝒟 is not a runtime validator.
+
+𝒟 defines the domain of epistemic curvature configurations that can exist as representable field states.
+
+---
+
+## 1. Base Field
+
+Let:
+
+\[
+\Sigma = \{\Sigma_1,\ldots,\Sigma_8\}
+\]
+
+be the fixed set of invariant axiomatic singularities.
+
+Let:
+
+\[
+R \in \mathfrak{so}(8)
+\]
+
+be the antisymmetric relational tension matrix, with:
+
+\[
+R_{ij}=-R_{ji}
+\]
+
+\[
+R_{ii}=0
+\]
+
+The epistemic field is:
+
+\[
+\Phi=(\Sigma,R)
+\]
+
+Φ is not an agent.  
+Φ is not a controller.  
+Φ is not an optimizer.  
+Φ is not a decision system.
+
+Φ is a relational epistemic field.
+
+---
+
+## 2. Relational Cochain Spaces
+
+Let:
+
+\[
+C^0
+\]
+
+be the space of scalar assignments to singularities.
+
+Let:
+
+\[
+C^1
+\]
+
+be the space of antisymmetric relational cochains on pairs of singularities.
+
+Let:
+
+\[
+C^2
+\]
+
+be the space of oriented triangular relational curvature cochains.
+
+Let:
+
+\[
+C^3
+\]
+
+be the space of oriented tetrahedral boundary-consistency cochains.
+
+Since \(|\Sigma|=8\):
+
+\[
+\dim C^0 = 8
+\]
+
+\[
+\dim C^1 = \binom{8}{2}=28
+\]
+
+\[
+\dim C^2 = \binom{8}{3}=56
+\]
+
+\[
+\dim C^3 = \binom{8}{4}=70
+\]
+
+These spaces are structural.
+
+They are not action spaces.
+
+They are not decision spaces.
+
+They are not optimization spaces.
+
+---
+
+## 3. Gauge Operator \(d_0\)
+
+Define:
+
+\[
+d_0:C^0\rightarrow C^1
+\]
+
+by:
+
+\[
+(d_0\varphi)_{ij}=\varphi_j-\varphi_i
+\]
+
+for scalar assignments:
+
+\[
+\varphi \in C^0
+\]
+
+This expresses relational gauge displacement.
+
+It does not create authority.
+
+It does not define preference.
+
+It does not privilege any singularity.
+
+---
+
+## 4. Curvature Operator \(d_1\)
+
+Define:
+
+\[
+d_1:C^1\rightarrow C^2
+\]
+
+by:
+
+\[
+(d_1R)_{ijk}=R_{ij}+R_{jk}+R_{ki}
+\]
+
+The epistemic curvature is:
+
+\[
+\Delta=d_1R
+\]
+
+Thus:
+
+\[
+\Delta \in C^2
+\]
+
+Δ is not an algorithmic output.
+
+Δ is the relational curvature induced by the field configuration \(R\).
+
+Because:
+
+\[
+d_1d_0=0
+\]
+
+curvature is invariant under relational gauge transformations:
+
+\[
+R\sim R+d_0\varphi
+\]
+
+Thus Δ does not encode absolute relational authority.
+
+It encodes only cyclic relational tension.
+
+---
+
+## 5. Boundary-Consistency Operator \(d_2\)
+
+Let:
+
+\[
+d_2:C^2\rightarrow C^3
+\]
+
+be the induced boundary-consistency operator satisfying:
+
+\[
+d_2d_1=0
+\]
+
+Therefore:
+
+\[
+d_2\Delta=0
+\]
+
+whenever:
+
+\[
+\Delta=d_1R
+\]
+
+Important clarification:
+
+\[
+d_2\Delta=0
+\]
+
+is a topological consistency condition.
+
+It must not be interpreted as a Hodge codifferential condition.
+
+It is not a minimization condition.
+
+It is not a smoothness objective.
+
+It is not an optimization constraint.
+
+---
+
+## 6. Algebraic Curvature Domain
+
+Define the algebraic curvature domain:
+
+\[
+\mathcal{D}_{\mathrm{alg}}=\operatorname{Im}(d_1)
+\]
+
+Equivalently:
+
+\[
+\mathcal{D}_{\mathrm{alg}}
+=
+\{
+\Delta\in C^2
+\mid
+\exists R\in\mathfrak{so}(8):\Delta=d_1R
+\}
+\]
+
+Because:
+
+\[
+d_2d_1=0
+\]
+
+every algebraic curvature configuration satisfies:
+
+\[
+d_2\Delta=0
+\]
+
+Thus:
+
+\[
+\Delta\in\mathcal{D}_{\mathrm{alg}}
+\Rightarrow
+d_2\Delta=0
+\]
+
+This is a structural condition.
+
+It is not a validity score.
+
+---
+
+## 7. Triality Action
+
+Let:
+
+\[
+\mathcal{T}
+\]
+
+be the declared finite triality action on \(C^2\).
+
+For:
+
+\[
+\tau\in\mathcal{T}
+\]
+
+define the induced signed cochain action:
+
+\[
+(\tau\cdot \Delta)_{ijk}
+=
+\operatorname{sgn}(\tau|_{ijk})\,
+\Delta_{\tau(i)\tau(j)\tau(k)}
+\]
+
+with the canonical antisymmetric extension on oriented triples.
+
+This action is declared structurally.
+
+It does not introduce:
+
+- a generator
+- a selector
+- an optimizer
+- a preferred axis
+- a privileged singularity
+- a decision mechanism
+
+Let:
+
+\[
+P_{\mathcal{T}}
+\]
+
+be the triality-invariant projection:
+
+\[
+P_{\mathcal{T}}
+=
+\frac{1}{|\mathcal{T}|}
+\sum_{\tau\in\mathcal{T}}\tau
+\]
+
+A curvature configuration is triality-balanced iff:
+
+\[
+P_{\mathcal{T}}\Delta=\Delta
+\]
+
+Triality does not generate configurations.
+
+Triality prevents degeneracy into a privileged representational axis.
+
+---
+
+## 8. Triality-Compatible Curvature Domain
+
+Define:
+
+\[
+\mathcal{D}_{\mathrm{tri}}
+=
+\mathcal{D}_{\mathrm{alg}}
+\cap
+\operatorname{Fix}(\mathcal{T})
+\]
+
+where:
+
+\[
+\operatorname{Fix}(\mathcal{T})
+=
+\{
+\Delta\in C^2
+\mid
+P_{\mathcal{T}}\Delta=\Delta
+\}
+\]
+
+Thus:
+
+\[
+\mathcal{D}_{\mathrm{tri}}
+=
+\{
+\Delta\in C^2
+\mid
+\exists R\in\mathfrak{so}(8):
+\Delta=d_1R,\;
+d_2\Delta=0,\;
+P_{\mathcal{T}}\Delta=\Delta
+\}
+\]
+
+\(\mathcal{D}_{\mathrm{tri}}\) is the triality-compatible structural domain.
+
+It is not yet the full admissible domain.
+
+Representability is still required.
+
+---
+
+## 9. Ontological Representability Predicate
+
+Define:
+
+\[
+\mathrm{Rep}(\Delta)\in\{0,1\}
+\]
+
+where:
+
+\[
+\mathrm{Rep}(\Delta)=1
+\]
+
+iff Δ can exist as a representable epistemic curvature configuration.
+
+Rep is not:
+
+- a metric
+- a score
+- an optimization target
+- a probability
+- a ranking function
+- a classifier
+- a policy
+- a deployment threshold
+
+Rep is an ontological predicate of representability.
+
+A curvature configuration fails representability if it:
+
+- privileges a single triality axis
+- forces dominance of one singularity
+- collapses 4ES plurality
+- induces prescriptive closure
+- destroys global relational readability
+- cannot sustain representable epistemic carrier status
+
+Rep does not decide.
+
+Rep does not filter.
+
+Rep does not command.
+
+Rep only marks whether a curvature configuration is ontologically representable.
+
+---
+
+## 10. Final Definition of 𝒟
+
+The admissible curvature domain is:
+
+\[
+\boxed{
+\mathcal{D}
+=
+\{
+\Delta\in C^2
+\mid
+\exists R\in\mathfrak{so}(8):
+\Delta=d_1R,\;
+d_2\Delta=0,\;
+P_{\mathcal{T}}\Delta=\Delta,\;
+\mathrm{Rep}(\Delta)=1
+\}
+}
+\]
+
+Equivalently:
+
+\[
+\boxed{
+\mathcal{D}
+=
+\mathcal{D}_{\mathrm{alg}}
+\cap
+\operatorname{Fix}(\mathcal{T})
+\cap
+\mathcal{R}_{\mathrm{rep}}
+}
+\]
+
+where:
+
+\[
+\mathcal{R}_{\mathrm{rep}}
+=
+\{
+\Delta\in C^2
+\mid
+\mathrm{Rep}(\Delta)=1
+\}
+\]
+
+𝒟 is the domain of admissible curvature.
+
+𝒟 is not computed as authority.
+
+𝒟 is not selected as a target.
+
+𝒟 is not optimized.
+
+𝒟 is the structural domain in which representable epistemic field states can exist.
+
+---
+
+## 11. Admissible Field Space \(E\)
+
+Define:
+
+\[
+E=\{\Phi=(\Sigma,R)\mid d_1R\in\mathcal{D}\}
+\]
+
+Thus:
+
+\[
+\Phi\in E
+\iff
+d_1R\in\mathcal{D}
+\]
+
+E is the space of representable epistemic field configurations.
+
+E is not a deployment set.
+
+E is not a decision space.
+
+E is not an action space.
+
+E is not a recommendation domain.
+
+---
+
+## 12. Coherence Predicate \(K(\Phi)\)
+
+Define:
+
+\[
+K(\Phi)\in\{0,1\}
+\]
+
+such that:
+
+\[
+\boxed{
+K(\Phi)=1
+\iff
+d_1R\in\mathcal{D}
+}
+\]
+
+\[
+\boxed{
+K(\Phi)=0
+\iff
+d_1R\notin\mathcal{D}
+}
+\]
+
+K is not optimized.
+
+K is not enforced.
+
+K is not selected.
+
+K is not a score.
+
+K is not a ranking.
+
+K is not a decision.
+
+K is a predicate of ontological representability.
+
+---
+
+## 13. ZMYSEL Carrier \(Ξ\)
+
+Define the epistemic carrier:
+
+\[
+\Xi=\{\Phi\mid K(\Phi)=1\}
+\]
+
+In the canonical 1.x interpretation:
+
+\[
+\Xi=E
+\]
+
+or equivalently:
+
+\[
+\Xi=d_1^{-1}(\mathcal{D})
+\]
+
+ZMYSEL is the carrier of representable epistemic existence.
+
+ZMYSEL is not an operator.
+
+ZMYSEL is not a mechanism.
+
+ZMYSEL is not a controller.
+
+ZMYSEL is not a decision system.
+
+It names the carrier condition under which epistemic existence remains representable.
+
+---
+
+## 14. Boundary \(κ\)
+
+Define:
+
+\[
+\kappa=\partial\mathcal{D}
+\]
+
+More precisely:
+
+\[
+\kappa=
+\partial_{\mathcal{D}_{\mathrm{tri}}}
+\mathcal{D}
+\]
+
+κ is the relative boundary of the ontologically representable domain inside the triality-compatible curvature space.
+
+κ is not:
+
+- numerical
+- tunable
+- measurable as a score
+- an optimization threshold
+- a deployment threshold
+- a classifier threshold
+- a safety cutoff
+
+κ is encountered only through loss of representability.
+
+κ is the boundary of ontological preservability / representability.
+
+---
+
+## 15. QE Condition
+
+Define:
+
+\[
+QE=\{\Phi\mid K(\Phi)=0\}
+\]
+
+Equivalently:
+
+\[
+\boxed{
+QE
+\iff
+d_1R\notin\mathcal{D}
+}
+\]
+
+QE is not failure.
+
+QE is not error.
+
+QE is not rejection.
+
+QE is not fallback.
+
+QE is not projection.
+
+QE is not represented field content.
+
+QE is the state of non-representability.
+
+When:
+
+\[
+d_1R\notin\mathcal{D}
+\]
+
+the field configuration does not belong to \(E\).
+
+The epistemic condition is QE.
+
+---
+
+## 16. Trajectory Admissibility
+
+A trajectory:
+
+\[
+\gamma=\{\Phi(t_0),\Phi(t_1),\ldots,\Phi(t_n)\}
+\]
+
+is admissible iff:
+
+\[
+\forall t_i:\; d_1R(t_i)\in\mathcal{D}
+\]
+
+Thus:
+
+\[
+\gamma\subset E
+\]
+
+If:
+
+\[
+\exists t_i:\; d_1R(t_i)\notin\mathcal{D}
+\]
+
+then:
+
+\[
+\gamma\cap QE\neq\emptyset
+\]
+
+and the trajectory is not representable.
+
+Trajectory admissibility is not path optimization.
+
+It is not trajectory ranking.
+
+It is not preference selection.
+
+It only marks whether every state in the trajectory remains inside the representable field space \(E\).
+
+---
+
+## 17. Non-Existence Principle
+
+If:
+
+\[
+\Delta\notin\mathcal{D}
+\]
+
+then:
+
+- no representable field state exists
+- no admissible trajectory exists
+- no projection can close coherently
+- no positive representable field-state status is granted
+
+This is not blocking.
+
+This is not rejection.
+
+This is not filtering.
+
+This is non-existence as a representable element of the epistemic carrier.
+
+QE is not projected.
+
+QE is not represented as field content.
+
+QE is the state of non-representability that occurs when:
+
+\[
+d_1R\notin\mathcal{D}
+\]
+
+If QE occurs, the system may only expose a non-representability marker.
+
+Such exposure is not a projection of QE.
+
+It is only a non-authoritative indication that no representable field state exists inside \(E\).
+
+---
+
+## 18. Non-Algorithmic Lock
+
+𝒟 must never be implemented as:
+
+- a classifier
+- a scoring function
+- a safety filter
+- an optimizer
+- a validator with authority
+- a decision mechanism
+- a ranking mechanism
+- a reward function
+- a policy boundary
+- a deployment threshold
+
+Any implementation may only approximate structural membership for audit or visualization.
+
+Such approximation does not become ontology.
+
+Such approximation does not become authority.
+
+Such approximation does not define 𝒟.
+
+The ontology remains primary.
+
+---
+
+## 19. Canonical Statement
+
+𝒟 is the domain of epistemic curvature configurations that can still exist as meaningful relational structures.
+
+Outside 𝒟 there is no forbidden state.
+
+There is only no representable state.
+
+QE is the state of non-representability.
+
+QE is not projected.
+
+Only a non-representability marker may be exposed.
+
+---
+
+## 20. Final Closure
+
+\[
+\boxed{
+\Phi=(\Sigma,R)
+}
+\]
+
+\[
+\boxed{
+\Delta=d_1R
+}
+\]
+
+\[
+\boxed{
+\mathcal{D}
+=
+\{
+\Delta
+\mid
+\Delta=d_1R,\;
+d_2\Delta=0,\;
+P_{\mathcal{T}}\Delta=\Delta,\;
+\mathrm{Rep}(\Delta)=1
+\}
+}
+\]
+
+\[
+\boxed{
+E=\{\Phi=(\Sigma,R)\mid d_1R\in\mathcal{D}\}
+}
+\]
+
+\[
+\boxed{
+K(\Phi)=1\iff d_1R\in\mathcal{D}
+}
+\]
+
+\[
+\boxed{
+\Xi=E=d_1^{-1}(\mathcal{D})
+}
+\]
+
+\[
+\boxed{
+\kappa=\partial_{\mathcal{D}_{\mathrm{tri}}}\mathcal{D}
+}
+\]
+
+\[
+\boxed{
+QE\iff d_1R\notin\mathcal{D}
+}
+\]
+
+---
+
+End of anchor.


### PR DESCRIPTION
This commit adds the ANCHOR_D_ADMISSIBLE_CURVATURE_DOMAIN.md file, which defines the admissible curvature domain of the VECTAETOS epistemic field, including its purpose, base field, relational cochain spaces, and various operators related to curvature and representability.