### PR TITLE
Revise README with explanation and formatting updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
 #### "Na prvý pohľad nemusí byť VECTAETOS okamžite intuitívny. Nie je však myslený ako pseudoveda, produktový alignment systém ani regulačný mechanizmus.
 
-VECTAETOS je post-AGI epistemická bezpečnostná architektúra:
-nechráni behaviorálnu poslušnosť inteligentných systémov, ale štrukturálnu
-reprezentovateľnosť stavov poznania.
+    VECTAETOS je post-AGI epistemická bezpečnostná architektúra:
+    nechráni behaviorálnu poslušnosť inteligentných systémov, ale štrukturálnu
+    reprezentovateľnosť stavov poznania.
 
-Takzvaný „Terminator problém“ nerieši ako zákaz alebo kontrolu agenta.
-Rámcuje ho skôr tak, že deštruktívne alebo dominačné konfigurácie sa na
-globálnej úrovni nečítajú ako preferované trajektórie, ale ako porušenie
-reprezentovateľnosti relačného poľa.
-
-LLM adaptéry a agentné wrappery nie sú autoritou pravdy.
-Sú iba downstream rozhrania, ktoré musia mať explicitne deklarované osi,
-role-boundaries a zákaz spätnej väzby do Φ."
+For a public-facing explanation of why VECTAETOS is a post-AGI epistemic
+security architecture rather than a behavioral alignment product, see
+[TERMINATOR_PROBLEM.md](./TERMINATOR_PROBLEM.md).
 ___
 ###  VECTAETOS™ (Onto-Epistemic Field © framework of structure) je neagentné noetické onto-dynamické relačno-tenzné epistemické pole, ktoré opisuje reprezentovateľnosť významu cez invariantné singularity, antisymetrické vzťahové napätia a hranicu nereprezentovateľnosti. 
 ___


### PR DESCRIPTION
Replaced original text with a public-facing explanation of VECTAETOS as a post-AGI epistemic security architecture. Updated formatting for clarity.