### PR TITLE
Add test to prevent pytest files in guard_core

### DIFF
--- a/tests/guards/core/test_no_tests_inside_guard_core.py
+++ b/tests/guards/core/test_no_tests_inside_guard_core.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_no_pytest_files_inside_guard_core_package() -> None:
+    guard_core = Path("guards/core")
+    forbidden = sorted(guard_core.glob("test_*.py"))
+
+    assert forbidden == [], (
+        "Pytest files must live under tests/guards/core/, "
+        "not inside guards/core/ implementation package."
+    )


### PR DESCRIPTION
Add a test to ensure no pytest files exist in the guard_core package.